### PR TITLE
Add AES-based ciphers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bouncycastle"]
+	path = bouncycastle
+	url = https://android.googlesource.com/platform/external/bouncycastle

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,18 @@
+Copyright (c) 2016 Stojan Dimitrovski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Android Ciphers
+
+This is a simple project that shows, through JUnit tests, how to use some sensible default cryptographic ciphers
+available on the Android platform.
+
+Take a look at `app/src/androidTest/java` to see the actual JUnit tests and the sensible defaults.
+
+Also, you may wish to checkout the submodule `bouncycastle` to actually browse the BouncyCastle code included in all
+Android systems and exposed through the `javax.crypto` API.
+
+## License
+
+All code contained herein, except where otherwise noted, is Copyright &copy; 2016 Stojan Dimitrovski and licensed under
+the permissive MIT X11 license.
+
+Consult the `LICENSE.txt` file for the full text.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId 'me.stojan.android.ciphers'
-        minSdkVersion 16
+        minSdkVersion 15
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
@@ -27,5 +27,5 @@ dependencies {
     testCompile 'junit:junit:4.12'
 
     androidTestCompile 'com.android.support.test:runner:0.4'
-
+    androidTestCompile 'com.android.support.test:rules:0.4'
 }

--- a/app/src/androidTest/java/me/stojan/android/ciphers/AECipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/AECipherTest.java
@@ -1,0 +1,24 @@
+package me.stojan.android.ciphers;
+
+import org.junit.Test;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import java.util.Random;
+
+public abstract class AECipherTest extends CipherTest {
+
+    @Test(expected = BadPaddingException.class)
+    public final void dataIntegrity() throws Exception {
+        final Cipher encrypt = encrypt();
+        final Cipher decrypt = decrypt();
+
+        final byte[] encrypted = encrypt.doFinal(BYTES);
+
+        final Random random = new Random();
+
+        encrypted[random.nextInt(encrypted.length)] += 1;
+
+        final byte[] decrypted = decrypt.doFinal(encrypted);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/CipherTest.java
@@ -1,0 +1,63 @@
+package me.stojan.android.ciphers;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.SmallTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+import javax.crypto.Cipher;
+import java.security.Key;
+
+@SmallTest
+@RunWith(AndroidJUnit4.class)
+public abstract class CipherTest {
+
+    protected static final String BOUNCY_CASTLE = "BC";
+
+    protected static final byte[] BYTES = (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eget est vitae quam sodales pretium. " +
+            "Aenean fringilla augue eget lobortis porttitor. Aliquam et justo malesuada, congue ex in, rhoncus " +
+            "risus. Nulla facilisi. Pellentesque habitant morbi tristique senectus et netus et malesuada fames " +
+            "ac turpis egestas. Vestibulum condimentum, mi quis ultrices bibendum, eros diam efficitur leo, vel" +
+            " lacinia est massa non metus. Suspendisse potenti. Maecenas egestas commodo lorem quis ultricies. " +
+            "Morbi fringilla sit amet diam sit amet volutpat. Vestibulum eleifend metus a maximus vestibulum. C" +
+            "urabitur facilisis lacus magna, nec feugiat dolor fringilla gravida. Maecenas ultricies massa magn" +
+            "a, et accumsan ex rutrum ac.\nSed tristique enim vitae volutpat vehicula. Phasellus egestas urna n" +
+            "ec mi rhoncus tincidunt. Aenean nec dictum ex, in facilisis turpis. Donec vel lacus vel dui luctus" +
+            " viverra. Nullam in libero orci. Mauris tempus mi in quam fringilla dictum. Nulla facilisi. Sed po" +
+            "rttitor eleifend porttitor. Integer lacinia cursus nulla, nec feugiat velit aliquet nec. Vestibulu" +
+            "m nisi tellus, scelerisque quis ultrices molestie, gravida sit amet lectus. Integer condimentum ma" +
+            "gna dui, non mollis lectus commodo sed. Integer eu porttitor ipsum. Pellentesque habitant morbi tr" +
+            "istique senectus et netus et malesuada fames ac turpis egestas cras amet.").getBytes();
+
+    private Key key;
+
+    @Before
+    public void setUp() throws Exception {
+        key = generateKey();
+    }
+
+    public abstract Key generateKey() throws Exception;
+
+    public Key obtainKey() {
+        return key;
+    }
+
+    @Test
+    public final void encryptDecryptCycle() throws Exception {
+        final Cipher encrypt = encrypt();
+        final Cipher decrypt = decrypt();
+
+        final byte[] encrypted = encrypt.doFinal(BYTES);
+        final byte[] decrypted = decrypt.doFinal(encrypted);
+
+        assertArrayEquals(BYTES, decrypted);
+    }
+
+    public abstract Cipher encrypt() throws Exception;
+
+    public abstract Cipher decrypt() throws Exception;
+
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBC128CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBC128CipherTest.java
@@ -1,0 +1,7 @@
+package me.stojan.android.ciphers.aes_cbc;
+
+public class AESCBC128CipherTest extends AESCBCCipherTest {
+    public AESCBC128CipherTest() {
+        super(128);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBC192CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBC192CipherTest.java
@@ -1,0 +1,7 @@
+package me.stojan.android.ciphers.aes_cbc;
+
+public class AESCBC192CipherTest extends AESCBCCipherTest {
+    public AESCBC192CipherTest() {
+        super(192);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBC256CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBC256CipherTest.java
@@ -1,0 +1,7 @@
+package me.stojan.android.ciphers.aes_cbc;
+
+public class AESCBC256CipherTest extends AESCBCCipherTest {
+    public AESCBC256CipherTest() {
+        super(256);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBCCipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_cbc/AESCBCCipherTest.java
@@ -1,0 +1,64 @@
+package me.stojan.android.ciphers.aes_cbc;
+
+import me.stojan.android.ciphers.CipherTest;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.Key;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+public abstract class AESCBCCipherTest extends CipherTest {
+
+    public static final String ALGORITHM = "AES";
+    public static final String MODE = "CBC";
+    public static final String PADDING = "PKCS7Padding";
+
+    public static final String TRANSFORMATION = ALGORITHM + "/" + MODE + "/" + PADDING;
+
+    private final int strength;
+
+    private IvParameterSpec iv;
+
+    protected AESCBCCipherTest(int strength) {
+        this.strength = strength;
+    }
+
+    @Override
+    public Key generateKey() throws Exception {
+        final KeyGenerator keyGenerator = KeyGenerator.getInstance(ALGORITHM, BOUNCY_CASTLE);
+
+        keyGenerator.init(strength);
+
+        final SecureRandom ivRandom = new SecureRandom();
+
+        final byte[] iv = new byte[16];
+
+        ivRandom.nextBytes(iv);
+
+        this.iv = new IvParameterSpec(iv);
+
+        Arrays.fill(iv, (byte) 0);
+
+        return keyGenerator.generateKey();
+    }
+
+    @Override
+    public Cipher encrypt() throws Exception {
+        final Cipher cipher = Cipher.getInstance(TRANSFORMATION, BOUNCY_CASTLE);
+
+        cipher.init(Cipher.ENCRYPT_MODE, obtainKey(), iv);
+
+        return cipher;
+    }
+
+    @Override
+    public Cipher decrypt() throws Exception {
+        final Cipher cipher = Cipher.getInstance(TRANSFORMATION, BOUNCY_CASTLE);
+
+        cipher.init(Cipher.DECRYPT_MODE, obtainKey(), iv);
+
+        return cipher;
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCM128CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCM128CipherTest.java
@@ -1,0 +1,7 @@
+package me.stojan.android.ciphers.aes_gcm;
+
+public class AESGCM128CipherTest extends AESGCMCipherTest {
+    public AESGCM128CipherTest() {
+        super(128);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCM192CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCM192CipherTest.java
@@ -1,0 +1,7 @@
+package me.stojan.android.ciphers.aes_gcm;
+
+public class AESGCM192CipherTest extends AESGCMCipherTest {
+    public AESGCM192CipherTest() {
+        super(192);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCM256CipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCM256CipherTest.java
@@ -1,0 +1,7 @@
+package me.stojan.android.ciphers.aes_gcm;
+
+public class AESGCM256CipherTest extends AESGCMCipherTest {
+    public AESGCM256CipherTest() {
+        super(256);
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCMCipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_gcm/AESGCMCipherTest.java
@@ -1,0 +1,64 @@
+package me.stojan.android.ciphers.aes_gcm;
+
+import me.stojan.android.ciphers.AECipherTest;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.spec.IvParameterSpec;
+import java.security.Key;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+public abstract class AESGCMCipherTest extends AECipherTest {
+
+    public static final String ALGORITHM = "AES";
+    public static final String MODE = "GCM";
+    public static final String PADDING = "NoPadding";
+
+    public static final String TRANSFORMATION = ALGORITHM + "/" + MODE + "/" + PADDING;
+
+    private final int strength;
+
+    private IvParameterSpec iv;
+
+    protected AESGCMCipherTest(int strength) {
+        this.strength = strength;
+    }
+
+    @Override
+    public Key generateKey() throws Exception {
+        final KeyGenerator keyGenerator = KeyGenerator.getInstance(ALGORITHM, BOUNCY_CASTLE);
+
+        keyGenerator.init(strength);
+
+        final SecureRandom ivRandom = new SecureRandom();
+
+        final byte[] iv = new byte[16];
+
+        ivRandom.nextBytes(iv);
+
+        this.iv = new IvParameterSpec(iv);
+
+        Arrays.fill(iv, (byte) 0);
+
+        return keyGenerator.generateKey();
+    }
+
+    @Override
+    public Cipher encrypt() throws Exception {
+        final Cipher cipher = Cipher.getInstance(TRANSFORMATION, BOUNCY_CASTLE);
+
+        cipher.init(Cipher.ENCRYPT_MODE, obtainKey(), iv);
+
+        return cipher;
+    }
+
+    @Override
+    public Cipher decrypt() throws Exception {
+        final Cipher cipher = Cipher.getInstance(TRANSFORMATION, BOUNCY_CASTLE);
+
+        cipher.init(Cipher.DECRYPT_MODE, obtainKey(), iv);
+
+        return cipher;
+    }
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_pbe/AESPBECipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_pbe/AESPBECipherTest.java
@@ -1,0 +1,58 @@
+package me.stojan.android.ciphers.aes_pbe;
+
+import android.util.Log;
+import me.stojan.android.ciphers.CipherTest;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import java.security.Key;
+
+public abstract class AESPBECipherTest extends CipherTest {
+
+    private final String algorithm;
+    private final int iterationCount;
+    private final char[] password;
+    private final byte[] salt;
+
+    public AESPBECipherTest(String algorithm, int iterationCount, char[] password, byte[] salt) {
+        this.algorithm = algorithm;
+        this.iterationCount = iterationCount;
+        this.password = password;
+        this.salt = salt;
+    }
+
+    @Override
+    public Key generateKey() throws Exception {
+        final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(algorithm, BOUNCY_CASTLE);
+
+        final Key key = keyFactory.generateSecret(new PBEKeySpec(password, salt, iterationCount));
+
+        Log.d("@@@", key.getAlgorithm());
+
+        key.getEncoded();
+
+        Log.d("@@@", key.getFormat());
+
+        return key;
+    }
+
+    @Override
+    public Cipher encrypt() throws Exception {
+        final Cipher cipher = Cipher.getInstance(algorithm, BOUNCY_CASTLE);
+
+        cipher.init(Cipher.ENCRYPT_MODE, obtainKey());
+
+        return cipher;
+    }
+
+    @Override
+    public Cipher decrypt() throws Exception {
+        final Cipher cipher = Cipher.getInstance(algorithm, BOUNCY_CASTLE);
+
+        cipher.init(Cipher.DECRYPT_MODE, obtainKey());
+
+        return cipher;
+    }
+
+}

--- a/app/src/androidTest/java/me/stojan/android/ciphers/aes_pbe/PBEWithSHA256AndAES256CBCCipherTest.java
+++ b/app/src/androidTest/java/me/stojan/android/ciphers/aes_pbe/PBEWithSHA256AndAES256CBCCipherTest.java
@@ -1,0 +1,9 @@
+package me.stojan.android.ciphers.aes_pbe;
+
+public class PBEWithSHA256AndAES256CBCCipherTest extends AESPBECipherTest {
+    public static final String ALGORITHM = "PBEWITHSHA256AND256BITAES-CBC-BC";
+
+    public PBEWithSHA256AndAES256CBCCipherTest() {
+        super(ALGORITHM, 2048, "password1".toCharArray(), "salty".getBytes());
+    }
+}


### PR DESCRIPTION
Adds three AES-based ciphers:
1. AES in CBC mode with 128, 192 and 256 bit keys
2. AES in GCM mode with 128, 192 and 256 bit keys
3. A password-based encryption cipher using AES 256 and SHA-256 as the key-derivation function, in CBC mode.
